### PR TITLE
About Page 2 image added

### DIFF
--- a/src/components/about/AboutSection2.tsx
+++ b/src/components/about/AboutSection2.tsx
@@ -1,5 +1,24 @@
+import Image from "next/image";
+import About from "@/public/about/about1.webp";
+
 const AboutSection2 = () => {
-  return <div>About Section 2</div>;
+  return (
+    <section className="bg-nsu-tan-100 relative flex flex-col items-start p-8 py-16">
+      <div className="relative z-1 w-2/5">
+        <Image
+          src={About}
+          alt="About Section 2 Main Image"
+          className="relative z-2 rounded-[1/2vw]"
+        />
+
+        <Image
+          src={About}
+          alt="Ghost Image"
+          className="absolute top-3 left-3 z-1 rounded-[1/2vw] opacity-40"
+        />
+      </div>
+    </section>
+  );
 };
 
 export default AboutSection2;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/43ddd09e-f913-4231-80d2-2378db9ac584)
Added About Section 2 image. 

I didn't end up adding the fish to About Section 2. I tried a little bit but the black fish isn't in the images and the red fish has part of the black fish cropped into it. 